### PR TITLE
Remove unnecessary hashing when comparing files

### DIFF
--- a/dduper
+++ b/dduper
@@ -27,6 +27,7 @@ from itertools import combinations
 from itertools import zip_longest
 from stat import *
 from timeit import default_timer as timer
+from filecmp import cmp
 from prettytable import PrettyTable
 
 #  4kb block size
@@ -125,26 +126,9 @@ def ioctl_fideduperange(src_fd, s):
         print("error({0})".format(e))
 
 
-def cmp_files(file1, file2):
-
-    md1 = subprocess.Popen(['sha256sum', file1],
-                           stdout=subprocess.PIPE,
-                           close_fds=True
-                           ).stdout.read().decode().split(" ")[0]
-    md2 = subprocess.Popen(['sha256sum', file2],
-                           stdout=subprocess.PIPE,
-                           close_fds=True
-                           ).stdout.read().decode().split(" ")[0]
-    if md1 == md2:
-        return 0
-    else:
-        return 1
-
-
 def validate_results(src_file, dst_file, bkup_file):
 
-    ret = cmp_files(dst_file, bkup_file)
-    if ret == 0:
+    if cmp(dst_file, bkup_file):
         print("Dedupe validation successful " + src_file + ":" + dst_file)
         # Removing temporary backup file path
         os.unlink(bkup_file)


### PR DESCRIPTION
[filecmp.cmp](https://docs.python.org/3/library/filecmp.html#filecmp.cmp):

1. Doesn't waste CPU time computing a hash
2. Is cached if the same file is compared more than once
3. Is portable to all Python platforms
4. Doesn't risk a (admittedly very unlikely) hash collision

It returns True if files are equal, False if not (opposite of the existing function) but is only used once.

**I haven't tested this.**  Please double-check that I'm understanding this correctly.