### PR TITLE
Dockerfile: fix build + optimizations + update Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
-FROM debian:buster-slim AS build
+FROM debian:bullseye-slim AS build
 MAINTAINER Lakshmipathi.G
 
-# Install needed dependencies.
-RUN apt-get update && apt-get install -y --no-install-recommends git autoconf automake gcc \
+# Install build dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends autoconf automake gcc \
     make pkg-config e2fslibs-dev libblkid-dev zlib1g-dev liblzo2-dev \
-    python3-dev libzstd-dev python-pip python3-setuptools patch
+    python3-dev libzstd-dev python3-pip python3-setuptools patch
 
-# Clone the repo
-RUN git clone https://github.com/Lakshmipathi/dduper.git && git clone https://github.com/kdave/btrfs-progs.git
+# Clone btrfs-progs repo
+ADD --checksum=sha256:e6512ff305963bc68f11803fa759fecbead778a3a951aeb4f7f3f76dabb31db4 https://github.com/kdave/btrfs-progs/archive/refs/tags/v6.1.3.tar.gz /btrfs-progs.tar.gz
+
+COPY patch/btrfs-progs-v6.1 /patch
 
 # Apply csum patch
 WORKDIR /btrfs-progs
-RUN patch -p1 < /dduper/patch/btrfs-progs-v5.6.1/0001-Print-csum-for-a-given-file-on-stdout.patch
+RUN tar --strip-components 1 -xzf /btrfs-progs.tar.gz && \
+    patch -p1 < /patch/0001-Print-csum-for-a-given-file-on-stdout.patch
 
 # Start the btrfs-progs build
 RUN ./autogen.sh
-RUN ./configure --disable-documentation
+# btrfs-progs 5.14 add an optional dependency (on by default) on libudev, for
+# multipath device detection, but that requires a running udev daemon, and
+# perhaps ohter changes to make it work inside a Docker container, so it's
+# disabled for the moment
+RUN ./configure --disable-documentation --disable-libudev
 RUN make install DESTDIR=/btrfs-progs-build
 
 # Start the btrfs-progs static build
@@ -25,18 +32,22 @@ RUN make btrfs.static
 RUN cp btrfs.static /btrfs-progs-build
 
 # Install dduper
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 COPY --from=build /lib/x86_64-linux-gnu/liblzo2.so.2 /lib/x86_64-linux-gnu/
 COPY --from=build /btrfs-progs-build /btrfs-progs
-COPY --from=build /dduper /dduper
+COPY . /dduper
 
 RUN mv /btrfs-progs/btrfs.static /
 RUN cp -rv /btrfs-progs/usr/local/bin/* /usr/local/bin && cp -rv /btrfs-progs/usr/local/include/* /usr/local/include/ && cp -rv /btrfs-progs/usr/local/lib/* /usr/local/lib
 RUN btrfs inspect-internal dump-csum --help
-RUN apt-get update && apt-get install -y --no-install-recommends python3-pip python3-setuptools
-WORKDIR /dduper
-RUN pip3 install -r requirements.txt && cp -v dduper /usr/sbin/
-RUN dduper --version
 
-# Remove packages
-RUN apt-get remove -y python3-pip python3-setuptools
+WORKDIR /dduper
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3-pip python3-setuptools && \
+    pip3 install -r requirements.txt && \
+    apt-get remove -y python3-pip python3-setuptools && \
+    rm -rf /var/lib/apt/lists/* && \
+    cp -v dduper /usr/sbin/ && \
+    dduper --version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 PTable
-pysqlite3
-
+pysqlite3-binary


### PR DESCRIPTION
Docker build is no longer working, as btrfs-progs and Python packages versions are not pinned. This PR fixes the build and makes some updates and optimizations. Summary of changes:

* Use `ADD` instead of Git
* Download only the kdave/btrfs-progs repo, use a `COPY` for the patch
* Verify the download with a checksum
* Pin the version to 6.1.3 (the latest for which a patch is available)
* Disable libudev
* Update to Debian Bullseye, because latest Numpy supports Python 3.9 to 3.12, but Buster has 3.7.3
* Use a single `RUN` in final stage and remove unneeded Apt files (see best practices: https://docs.docker.com/develop/develop-images/instructions/#run)
* requirements.txt: use `pysqlite3-binary` instead of `pysqlite3` to get a precompiled binary (otherwise, build tools are required to build sqlite3)