### PR TITLE
Remove pysqlite3-binary from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 PTable
-pysqlite3-binary


### PR DESCRIPTION
Was added in my previous commit to replace pysqlite3 (which would require build tools in Bullseye). However, I didn't realize [it is part of the standard library](https://docs.python.org/3/library/sqlite3.html), so no separate install should be needed.

The Docker image continues to be functional.