### PR TITLE
Add patches for btrfs-progs v6.3.3

### DIFF
--- a/patch/btrfs-progs-v6.3.3/0001-Print-csum-for-a-given-file-on-stdout.patch
+++ b/patch/btrfs-progs-v6.3.3/0001-Print-csum-for-a-given-file-on-stdout.patch
@@ -1,0 +1,303 @@
+From c2404830ec792b2a0e07881912e0f3844eaca184 Mon Sep 17 00:00:00 2001
+From: Anna Lee <150648636+a-n-n-a-l-e-e@users.noreply.github.com>
+Date: Wed, 15 Nov 2023 07:02:43 +0000
+Subject: [PATCH] Print csum for a given file on stdout
+
+---
+ Makefile                 |   2 +-
+ cmds/commands.h          |   1 +
+ cmds/inspect-dump-csum.c | 244 +++++++++++++++++++++++++++++++++++++++
+ cmds/inspect.c           |   1 +
+ 4 files changed, 247 insertions(+), 1 deletion(-)
+ create mode 100644 cmds/inspect-dump-csum.c
+
+diff --git a/Makefile b/Makefile
+index 30d48ef2..5facde30 100644
+--- a/Makefile
++++ b/Makefile
+@@ -224,7 +224,7 @@ objects = \
+ 	libbtrfsutil/stubs.o	\
+ 	libbtrfsutil/subvolume.o
+ 
+-cmds_objects = cmds/subvolume.o cmds/subvolume-list.o \
++cmds_objects = cmds/subvolume.o cmds/subvolume-list.o cmds/inspect-dump-csum.o \
+ 	       cmds/filesystem.o cmds/device.o cmds/scrub.o \
+ 	       cmds/inspect.o cmds/balance.o cmds/send.o cmds/receive.o \
+ 	       cmds/quota.o cmds/qgroup.o cmds/replace.o check/main.o \
+diff --git a/cmds/commands.h b/cmds/commands.h
+index 5ab7c881..df62c6b1 100644
+--- a/cmds/commands.h
++++ b/cmds/commands.h
+@@ -139,6 +139,7 @@ DECLARE_COMMAND(device);
+ DECLARE_COMMAND(scrub);
+ DECLARE_COMMAND(check);
+ DECLARE_COMMAND(inspect);
++DECLARE_COMMAND(inspect_dump_csum);
+ DECLARE_COMMAND(inspect_dump_super);
+ DECLARE_COMMAND(inspect_dump_tree);
+ DECLARE_COMMAND(inspect_tree_stats);
+diff --git a/cmds/inspect-dump-csum.c b/cmds/inspect-dump-csum.c
+new file mode 100644
+index 00000000..e61c09c3
+--- /dev/null
++++ b/cmds/inspect-dump-csum.c
+@@ -0,0 +1,244 @@
++/*
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public
++ * License v2 as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public
++ * License along with this program; if not, write to the
++ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
++ * Boston, MA 021110-1307, USA.
++ */
++
++#include "kerncompat.h"
++#include <stdio.h>
++#include <stdlib.h>
++#include <unistd.h>
++#include <fcntl.h>
++#include <sys/stat.h>
++#include <ctype.h>
++#include <uuid/uuid.h>
++#include <errno.h>
++#include <getopt.h>
++
++#include "kernel-shared/ctree.h"
++#include "kernel-shared/disk-io.h"
++#include "kernel-shared/print-tree.h"
++#include "kernel-shared/transaction.h"
++#include "kernel-lib/list.h"
++#include "common/utils.h"
++#include "cmds/commands.h"
++#include "crypto/crc32c.h"
++#include "common/help.h"
++#include "kernel-shared/volumes.h"
++
++
++static const char * const cmd_inspect_dump_csum_usage[] = {
++	"btrfs inspect-internal dump-csum <path/to/file> <device>",
++	"Get csums for the given file.",
++	NULL
++};
++
++static int btrfs_lookup_csums(struct btrfs_trans_handle *trans, struct btrfs_root *root,
++	struct btrfs_path *path, u64 bytenr, int cow, int total_csums)
++{
++	int ret;
++	int i;
++	int start_pos = 0;
++	struct btrfs_key file_key;
++	struct btrfs_key found_key;
++	struct btrfs_csum_item *item;
++	struct extent_buffer *leaf;
++	u64 csum_offset = 0;
++	u16 csum_size =
++		btrfs_super_csum_size(root->fs_info->super_copy);
++	int csums_in_item = 0;
++	unsigned int tree_csum = 0;
++	int pending_csums = total_csums;
++	static int cnt=1;
++
++	file_key.objectid = BTRFS_EXTENT_CSUM_OBJECTID;
++	file_key.offset = bytenr;
++	file_key.type = BTRFS_EXTENT_CSUM_KEY;
++	ret = btrfs_search_slot(trans, root, &file_key, path, 0, cow);
++	if (ret < 0)
++		goto fail;
++	while(1){
++		leaf = path->nodes[0];
++		if (ret > 0) {
++			ret = 1;
++			if (path->slots[0] == 0)
++				goto fail;
++			path->slots[0]--;
++			btrfs_item_key_to_cpu(leaf, &found_key, path->slots[0]);
++			if (found_key.type != BTRFS_EXTENT_CSUM_KEY){
++				fprintf(stderr, "\nInvalid key found.");
++				goto fail;
++			}
++
++			csum_offset = ((bytenr - found_key.offset) / root->fs_info->sectorsize) * csum_size;
++			csums_in_item = btrfs_item_size(leaf, path->slots[0]);
++			csums_in_item /= csum_size;
++			csums_in_item -= ( bytenr - found_key.offset ) / root->fs_info->sectorsize;
++			start_pos=csum_offset;
++		}
++		if (path->slots[0] >= btrfs_header_nritems(leaf)) {
++			if (pending_csums > 0){
++				ret = btrfs_next_leaf(root, path);
++				if (ret == 0)
++				      continue;
++			}
++		}
++		item = btrfs_item_ptr(leaf, path->slots[0], struct btrfs_csum_item);
++		btrfs_item_key_to_cpu(leaf, &found_key, path->slots[0]);
++		if (!ret){
++			start_pos=0;
++			csum_offset = ( bytenr - found_key.offset ) / root->fs_info->sectorsize;
++			csums_in_item = btrfs_item_size(leaf, path->slots[0]);
++			csums_in_item /= csum_size;
++		}
++		if (csums_in_item > pending_csums){
++			//possibly,some other csums on this item.
++			for(i = 0; i < pending_csums; i++, cnt++){
++			read_extent_buffer(leaf, &tree_csum,
++					(unsigned long)item + ((i*csum_size)+start_pos) , csum_size);
++			fprintf(stdout, "%x ", tree_csum);
++			if (cnt % 8 == 0)
++				fprintf(stdout, "\n");
++			}
++			pending_csums = 0;
++			return 0;
++		}else{
++			for(i = 0; i < csums_in_item; i++, cnt++){
++			read_extent_buffer(leaf, &tree_csum,
++					(unsigned long)item+((i*csum_size)+start_pos), csum_size);
++			fprintf(stdout, "%x ", tree_csum);
++			if (cnt % 8 == 0)
++				fprintf(stdout, "\n");
++			}
++		}
++		pending_csums -= csums_in_item;
++		ret = 0;
++		if (pending_csums > 0){
++			path->slots[0]++;
++
++		}else
++			return 0;
++	}
++fail:
++	fprintf(stderr, "btrfs_lookup_csums search failed.");
++	if (ret > 0)
++		ret = -ENOENT;
++	return ret;
++}
++
++static int btrfs_lookup_extent(struct btrfs_fs_info *info, struct btrfs_path *path,
++		u64 ino, int cow){
++	struct btrfs_key key;
++	struct btrfs_key found_key;
++	struct btrfs_file_extent_item *fi;
++	struct extent_buffer *leaf;
++	struct btrfs_root *fs_root;
++	int ret = -1;
++	int slot;
++	int total_csums = 0;
++	u64 bytenr;
++	u64 itemnum = 0;
++	struct btrfs_path *path1 = NULL;
++
++	fs_root = info->fs_root;
++	key.objectid = ino;
++	key.type = BTRFS_EXTENT_DATA_KEY;
++	key.offset = 0;
++	ret = btrfs_search_slot(NULL,fs_root,&key,path,0,0);
++
++	if(ret < 0)
++		goto error;
++
++	if (ret > 1){
++		fprintf(stderr, "Unable to find the entry");
++		return ret;
++	}
++	struct btrfs_root *csum_root = btrfs_csum_root(info, 0);
++	u16 csum_size = btrfs_super_csum_size(csum_root->fs_info->super_copy);
++	while(1){
++		leaf = path->nodes[0];
++		slot = path->slots[0];
++		if (slot >=  btrfs_header_nritems(leaf)){
++		       ret = btrfs_next_leaf(fs_root, path);
++			       if (ret == 0)
++				      continue;
++			       if (ret < 0)
++				      goto error;
++		}
++		btrfs_item_key_to_cpu(leaf, &found_key, slot);
++		if (found_key.type != BTRFS_EXTENT_DATA_KEY){
++			btrfs_release_path(path);
++			return -EINVAL;
++		}
++
++		fi = btrfs_item_ptr(leaf, slot, struct btrfs_file_extent_item);
++		bytenr = btrfs_file_extent_disk_bytenr(leaf, fi);
++		total_csums=(btrfs_file_extent_num_bytes(leaf, fi) / 1024) / csum_size;
++		path->slots[0]++;
++		itemnum++;
++		path1 = btrfs_alloc_path();
++		csum_root = btrfs_csum_root(info, 0);
++		ret = btrfs_lookup_csums(NULL,csum_root, path1, bytenr, 0,
++					total_csums);
++		btrfs_release_path(path1);
++		if (ret) {
++			fprintf(stderr, "\n Error: btrfs_lookup_csum");
++			return 1;
++		}
++	}
++
++error:
++	btrfs_release_path(path);
++	return ret;
++}
++
++static int cmd_inspect_dump_csum(const struct cmd_struct *cmd,
++				  int argc, char **argv)
++{
++	struct btrfs_fs_info *info;
++	int ret;
++	struct btrfs_path path = { 0 };
++	struct stat st;
++	char *filename;
++	struct open_ctree_args oca = { 0 };
++	oca.flags = OPEN_CTREE_PARTIAL;
++	oca.filename = argv[2];
++
++	if (check_argc_exact(argc, 3))
++		usage_unknown_option(cmd, argv);
++
++	filename = argv[1];
++	info = open_ctree_fs_info(&oca);
++	if (!info) {
++		fprintf(stderr, "unable to open %s\n", argv[2]);
++		exit(1);
++	}
++
++	ret = stat(filename, &st);
++	if (ret < 0)	{
++		fprintf(stderr, "unable to open %s\n", filename);
++		exit(1);
++	}
++
++	if(st.st_size < 1024){
++		fprintf(stderr, "file less than 1KB.abort%lu", (st.st_size ));
++		exit(1);
++	}
++
++	ret = btrfs_lookup_extent(info, &path, st.st_ino, 0);
++	ret = close_ctree(info->fs_root);
++	btrfs_close_all_devices();
++
++	return ret;
++}
++DEFINE_SIMPLE_COMMAND(inspect_dump_csum, "dump-csum");
+diff --git a/cmds/inspect.c b/cmds/inspect.c
+index 117efb51..4d9292b9 100644
+--- a/cmds/inspect.c
++++ b/cmds/inspect.c
+@@ -1537,6 +1537,7 @@ static const struct cmd_group inspect_cmd_group = {
+ 		&cmd_struct_inspect_dump_tree,
+ 		&cmd_struct_inspect_dump_super,
+ 		&cmd_struct_inspect_tree_stats,
++		&cmd_struct_inspect_dump_csum,
+ #if EXPERIMENTAL
+ 		&cmd_struct_inspect_list_chunks,
+ #endif
+-- 
+2.42.0
+


### PR DESCRIPTION
just minor edits to the v6.1 patch:

open_ctree_flags renamed to open_ctree_args in v6.3.3

btrfs_init_path which zeros out the btrfs_path arg is removed in v6.5.2; zero initialize the struct instead.

to see a diff of the v6.1 and v6.3.3 patches
```sh
diff -uw <(curl -sL 'https://raw.githubusercontent.com/Lakshmipathi/dduper/ecc2664c380616ec75cfc1e600b5514cdff5c687/patch/btrfs-progs-v6.1/0001-Print-csum-for-a-given-file-on-stdout.patch') <(curl -sL 'https://raw.githubusercontent.com/Lakshmipathi/dduper/1f1d29eff61430e118f88239545a29f0bcf3e15d/patch/btrfs-progs-v6.3.3/0001-Print-csum-for-a-given-file-on-stdout.patch')
```