### PR TITLE
ci: add release pipeline, security scanning, and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    cooldown:
+      # github-actions ecosystem does not support semver-classified
+      # cooldown keys; only default-days is honoured here.
+      default-days: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -1,0 +1,265 @@
+name: Build and Release Deb
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.0.5). Leave blank to build current ref without publishing.'
+        required: false
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  check-version:
+    name: Check Cargo.toml version against tag
+    runs-on: ubuntu-latest
+    outputs:
+      mismatch: ${{ steps.check.outputs.mismatch }}
+      tag_version: ${{ steps.check.outputs.tag_version }}
+      cargo_version: ${{ steps.check.outputs.cargo_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Compare Cargo.toml version with tag
+        id: check
+        run: |
+          set -euo pipefail
+          cargo_ver=$(awk -F'"' '/^version = /{print $2; exit}' Cargo.toml)
+          if [ -z "${cargo_ver}" ]; then
+            echo "::error::Could not parse version from Cargo.toml"
+            exit 1
+          fi
+
+          tag_ver=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            input_tag="${{ github.event.inputs.tag }}"
+            if [ -n "${input_tag}" ]; then
+              tag_ver="${input_tag#v}"
+            fi
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            tag_ver="${GITHUB_REF_NAME#v}"
+          fi
+
+          echo "cargo_version=${cargo_ver}" >> "$GITHUB_OUTPUT"
+          echo "tag_version=${tag_ver}" >> "$GITHUB_OUTPUT"
+
+          if [ -z "${tag_ver}" ]; then
+            echo "::notice::No tag context (workflow_dispatch without tag input); skipping comparison."
+            echo "mismatch=false" >> "$GITHUB_OUTPUT"
+          elif [ "${cargo_ver}" != "${tag_ver}" ]; then
+            echo "::warning::Cargo.toml version (${cargo_ver}) does not match tag (${tag_ver}). Cargo.toml will be patched in-build, and a follow-up PR will be opened to make the bump permanent."
+            echo "mismatch=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Cargo.toml version (${cargo_ver}) matches tag (${tag_ver})."
+            echo "mismatch=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build deb (${{ matrix.target }})
+    needs: check-version
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            deb_arch: amd64
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            deb_arch: arm64
+            cross: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Patch Cargo.toml to match tag version
+        if: needs.check-version.outputs.mismatch == 'true'
+        env:
+          TAG_VERSION: ${{ needs.check-version.outputs.tag_version }}
+        run: |
+          set -euo pipefail
+          sed -i.bak -E "s/^version = \"[^\"]+\"/version = \"${TAG_VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
+          echo "Patched Cargo.toml to version ${TAG_VERSION}:"
+          grep '^version = ' Cargo.toml
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # branch:stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry and target
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.target }}-
+
+      - name: Install cross-compilation toolchain
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+
+      - name: Build release binary
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build deb package
+        run: |
+          cargo deb \
+            --no-build \
+            --target ${{ matrix.target }} \
+            --output target/${{ matrix.target }}/debian/
+
+      - name: Locate deb artifact
+        id: deb
+        run: |
+          deb_path=$(ls target/${{ matrix.target }}/debian/*.deb | head -n 1)
+          echo "path=${deb_path}" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "${deb_path}")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ steps.deb.outputs.name }}
+          path: ${{ steps.deb.outputs.path }}
+          if-no-files-found: error
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          file: ${{ steps.deb.outputs.path }}
+          format: cyclonedx-json
+          output-file: ${{ steps.deb.outputs.name }}.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          file: ${{ steps.deb.outputs.path }}
+          format: spdx-json
+          output-file: ${{ steps.deb.outputs.name }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: sbom-${{ matrix.target }}
+          path: |
+            ${{ steps.deb.outputs.name }}.cdx.json
+            ${{ steps.deb.outputs.name }}.spdx.json
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    needs: [check-version, build]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download deb artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -lR artifacts
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4.1.1
+
+      - name: Sign deb files (keyless via Sigstore)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          for deb in artifacts/*.deb; do
+            cosign sign-blob \
+              --yes \
+              --bundle "${deb}.bundle" \
+              "${deb}"
+          done
+          ls -l artifacts
+
+      - name: Attest build provenance for deb files
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: 'artifacts/*.deb'
+
+      - name: Create release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
+        with:
+          files: |
+            artifacts/*.deb
+            artifacts/*.deb.bundle
+            artifacts/*.cdx.json
+            artifacts/*.spdx.json
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+
+  sync-cargo-version:
+    name: Open PR to sync Cargo.toml version with tag
+    needs: [check-version, build, release]
+    if: needs.check-version.outputs.mismatch == 'true' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: master
+
+      - name: Patch Cargo.toml on master
+        env:
+          TAG_VERSION: ${{ needs.check-version.outputs.tag_version }}
+        run: |
+          set -euo pipefail
+          sed -i.bak -E "s/^version = \"[^\"]+\"/version = \"${TAG_VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
+
+      - name: Open follow-up PR
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        with:
+          branch: chore/bump-cargo-version-${{ needs.check-version.outputs.tag_version }}
+          base: master
+          title: "chore: bump Cargo.toml version to ${{ needs.check-version.outputs.tag_version }}"
+          commit-message: "chore: bump Cargo.toml version to ${{ needs.check-version.outputs.tag_version }}"
+          body: |
+            ## Why
+
+            `v${{ needs.check-version.outputs.tag_version }}` was just released (see ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}), but `Cargo.toml` on `master` is still pinned at `${{ needs.check-version.outputs.cargo_version }}`. The release workflow patched `Cargo.toml` transiently for the build so the produced `.deb` is named correctly; this PR makes that bump permanent on `master`.
+
+            Auto-opened by `release-deb.yml` after the release published.
+          delete-branch: true
+          labels: |
+            chore
+            automated

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,133 @@
+name: Security
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-audit:
+    name: cargo-audit (RustSec advisories)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # branch:stable
+
+      - name: Cache cargo-audit binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-cargo-audit-bin
+
+      - name: Install cargo-audit
+        run: |
+          if ! command -v cargo-audit >/dev/null 2>&1; then
+            cargo install --locked cargo-audit
+          fi
+
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      - name: Run cargo-audit
+        run: cargo audit --deny warnings
+
+  cargo-deny:
+    name: cargo-deny (advisories, bans, sources)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb  # v2.0.17
+        with:
+          # No deny.toml in repo yet — restrict to checks that work without
+          # configuration. Add `licenses` once a deny.toml is committed.
+          command: check advisories bans sources
+
+  gitleaks:
+    name: gitleaks (secret scan)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          VERSION: 8.21.2
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --no-banner --redact --verbose
+
+  codeql:
+    name: CodeQL (Rust)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
+        with:
+          languages: rust
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
+        with:
+          category: "/language:rust"
+
+  trivy:
+    name: trivy (filesystem scan)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-results.sarif
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,27 @@ edition = "2021"
 license = "GPL-2.0"
 description = "BTRFS block-level deduplication tool"
 
+[package.metadata.deb]
+maintainer = "Lakshmipathi Ganapathi <lakshmipathi.g@gmail.com>"
+copyright = "Lakshmipathi Ganapathi <lakshmipathi.g@gmail.com>"
+license-file = ["COPYING", "0"]
+extended-description = """\
+dduper performs BTRFS block-level deduplication by leveraging BTRFS
+checksums to detect duplicate blocks without re-reading file contents,
+making it significantly faster than offline dedup tools that re-hash
+data. Supports per-file and recursive directory dedup with an optional
+SQLite checksum cache."""
+section = "admin"
+priority = "optional"
+depends = "$auto, libc6"
+assets = [
+    ["target/release/dduper", "usr/sbin/dduper", "755"],
+    ["bin/btrfs.static", "usr/sbin/dduper-btrfs", "755"],
+    ["README.md", "usr/share/doc/dduper/README.md", "644"],
+    ["INSTALL.md", "usr/share/doc/dduper/INSTALL.md", "644"],
+    ["CHANGELOG", "usr/share/doc/dduper/changelog", "644"],
+]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 rusqlite = { version = "0.31", features = ["bundled"] }


### PR DESCRIPTION
Adds three GitHub-side workflow files plus a Dependabot configuration:

- .github/workflows/release-deb.yml — on `v*` tag pushes, builds amd64 and arm64 .deb packages via cargo-deb, generates CycloneDX + SPDX SBOMs, signs each .deb keyless via Sigstore (cosign + --bundle), emits a SLSA build-provenance attestation, and publishes a GitHub release with all artifacts attached. Also patches Cargo.toml's version in-runner if it drifts from the tag, and opens an auto chore PR to make the bump permanent.
- .github/workflows/security.yml — runs cargo-audit, cargo-deny (advisories+bans+sources), gitleaks, CodeQL with the security-and-quality query suite, and Trivy filesystem scan with SARIF upload to GitHub code scanning. Triggers on push, PR, and a weekly cron.
- .github/dependabot.yml — weekly grouped updates for the cargo and github-actions ecosystems. Adds cooldown windows (5 days for cargo, plus 14 for major; 5 days flat for github-actions, which doesn't honour semver-classified cooldown) so newly-published dependency versions sit out the typical 24-48h supply-chain-attack detection window before Dependabot opens a bump PR.

Every `uses:` reference is pinned to a 40-char commit SHA with a trailing `# vX.Y.Z` comment, so future bumps go through Dependabot review rather than tag-rewrite.

Also adds a [package.metadata.deb] section to Cargo.toml so the new release pipeline (release-deb.yml) can build a Debian package with correct paths, deps, and copyright.