### PR TITLE
deps: bump rust dependencies and switch digest formatting to hex::encode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,14 @@ description = "BTRFS block-level deduplication tool"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-rusqlite = { version = "0.31", features = ["bundled"] }
-sha2 = "0.10"
+rusqlite = { version = "0.39", features = ["bundled"] }
+sha2 = "0.11"
 libc = "0.2"
 regex = "1"
 comfy-table = "7"
-itertools = "0.13"
+itertools = "0.14"
 log = "0.4"
 env_logger = "0.11"
 walkdir = "2"
 anyhow = "1"
+hex = "0.4"

--- a/src/csum.rs
+++ b/src/csum.rs
@@ -32,7 +32,7 @@ pub fn compute_csum_hash(csums: &[String]) -> String {
     let mut hasher = Sha256::new();
     let repr = format!("{:?}", csums);
     hasher.update(repr.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 /// Fetch BTRFS checksums directly (no cache)
@@ -102,7 +102,7 @@ pub fn get_hashes(
         for (idx, csum) in csums.iter().enumerate() {
             let mut hasher = Sha256::new();
             hasher.update(csum.as_bytes());
-            let hash = format!("{:x}", hasher.finalize());
+            let hash = hex::encode(hasher.finalize());
 
             let entry = hash_map.entry(hash.clone()).or_default();
             if !entry.is_empty() {
@@ -122,7 +122,7 @@ pub fn get_hashes(
                 .join("");
             let mut hasher = Sha256::new();
             hasher.update(chunk_str.as_bytes());
-            let hash = format!("{:x}", hasher.finalize());
+            let hash = hex::encode(hasher.finalize());
 
             let entry = hash_map.entry(hash.clone()).or_default();
             if !entry.is_empty() {

--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -136,7 +136,7 @@ fn sha256_file(path: &Path) -> Result<String> {
         }
         hasher.update(&buffer[..n]);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hex::encode(hasher.finalize()))
 }
 
 /// Validate dedup results by comparing dst with its backup


### PR DESCRIPTION
- itertools 0.13 -> 0.14
- rusqlite  0.31 -> 0.39
- sha2      0.10 -> 0.11
- hex       0.4  (new)

sha2 0.11 changed Digest::finalize()'s return type from GenericArray to Array, which dropped the std::fmt::LowerHex impl. The four sites using format!(\"{:x}\", hasher.finalize()) in src/csum.rs and src/dedupe.rs are now hex::encode(hasher.finalize()), which produces the same lowercase hex output and works against both pre- and post- sha2 0.11 return types.